### PR TITLE
Start scaffolding some of the types and APIs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.19.x, 1.20.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -38,5 +38,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.19.x'
+        if: matrix.go-version == '1.20.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - cyclop            # covered by gocyclo
     - deadcode          # abandoned
     - exhaustivestruct  # replaced by exhaustruct
+    - exhaustruct       # not helpful, prevents idiomatic struct literals
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt

--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0

--- a/client.go
+++ b/client.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpbalancer
+
+import "net/http"
+
+// ClientOption is an option used to customize the behavior of an HTTP client.
+type ClientOption interface {
+	apply(*clientOptions)
+}
+
+// NewClient returns a new HTTP client that uses the given options.
+func NewClient(options ...ClientOption) *http.Client {
+	var opts clientOptions
+	for _, opt := range options {
+		opt.apply(&opts)
+	}
+	// TODO: implement me
+	return &http.Client{
+		Transport:     newTransport(&opts),
+		CheckRedirect: opts.redirectFunc,
+	}
+}
+
+type clientOptions struct {
+	redirectFunc func(req *http.Request, via []*http.Request) error
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpbalancer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: make real tests... this is just a simple "smoke test" that the current
+//	     scaffolding for the hierarchy of transports results in a usable client
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	svr := http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(([]byte)("got it"))
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		err := svr.Serve(listener)
+		require.Equal(t, http.ErrServerClosed, err)
+	}()
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithCancel(ctx)
+		defer shutdownCancel()
+		err := svr.Shutdown(shutdownCtx)
+		require.NoError(t, err)
+	}()
+
+	cl := NewClient()
+	url := fmt.Sprintf("http://%s/foo", listener.Addr().String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := cl.Do(req)
+	require.NoError(t, err)
+	defer func() {
+		err := resp.Body.Close()
+		require.NoError(t, err)
+	}()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "got it", string(body))
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httpbalancer provides http.Client instances that are suitable
+// for use for server-to-server communications, like RPC. This adds features
+// on top of the standard net/http library for name/address resolution,
+// health checking, connection management and subsetting, and load balancing.
+// It also provides more suitable defaults and much simpler support for
+// HTTP/2 over plaintext.
+package httpbalancer

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/bufbuild/go-http-balancer
 
 go 1.19
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/transport.go
+++ b/transport.go
@@ -12,12 +12,187 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package httpbalancer provides http.Client instances that are suitable
-// for use for server-to-server communications, like RPC. This adds features
-// on top of the standard net/http library for name/address resolution,
-// health checking, connection management and subsetting, and load balancing.
-// It also provides more suitable defaults and much simpler support for
-// HTTP/2 over plaintext.
 package httpbalancer
 
-// TODO: Implement me!!
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// TODO: add this info (whatever's relevant/user-visible) to doc.go
+
+// This package uses a hierarchy with three-layers of transports:
+//
+// 1. mainTransport: This is the "top" of the hierarchy and is the
+//    http.RoundTripper used by NewClient. This transport manages a
+//    collection of other transports, grouped by URL scheme and
+//    hostname:port.
+// 2. transportPool: This provides a pool of transports for a single
+//    URL schema and hostname:port. This is the layer in which most
+//    of the features are implemented: name resolution, health
+//    checking, and load balancing (sub-setting and picking). Each
+//    transportPool manages a pool of lower-level transports, each
+//    to a potentially different resolved address.
+// 3. http.RoundTripper: The bottom of the hierarchy is a normal
+//    round tripper, such as *http.Transport. This represents a
+//    logical connection to a single resolved address. It may
+//    actually represent more than one physical connection, like
+//    when using HTTP 1.1 and multiple active requests are made
+//    to the same address.
+
+type mainTransport struct {
+	mu    sync.RWMutex
+	pools map[target]*transportPool
+}
+
+func newTransport(_ *clientOptions) *mainTransport {
+	// TODO
+	return &mainTransport{
+		pools: map[target]*transportPool{},
+	}
+}
+
+func (m *mainTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	dest := target{scheme: request.URL.Scheme, hostPort: request.URL.Host}
+	pool := m.getPool(dest)
+	return pool.RoundTrip(request)
+}
+
+func (m *mainTransport) getPool(dest target) http.RoundTripper {
+	m.mu.RLock()
+	pool := m.pools[dest]
+	m.mu.RUnlock()
+
+	if pool != nil {
+		return pool
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// double-check in case pool was added while upgrading lock
+	pool = m.pools[dest]
+	if pool != nil {
+		return pool
+	}
+
+	pool = newTransportPool(dest.scheme, dest.hostPort, simpleFactory{})
+	// TODO: evict unused/idle entries from map (maybe accept "warm set"
+	//       in config, for targets to keep warm, that never get evicted)
+	m.pools[dest] = pool
+	return pool
+}
+
+type target struct {
+	scheme   string
+	hostPort string
+}
+
+type transportPool struct {
+	scheme              string
+	roundTripperFactory RoundTripperFactory
+	resolved            <-chan struct{}
+
+	mu sync.RWMutex
+	// TODO: we may need better data structures than this to
+	//       support "picker" interface and efficient selection
+	pool  map[string][]connection
+	conns []connection
+}
+
+func newTransportPool(scheme, hostPort string, factory RoundTripperFactory) *transportPool {
+	// TODO: implement me!!
+	resolved := make(chan struct{})
+
+	pool := &transportPool{
+		scheme:              scheme,
+		roundTripperFactory: factory,
+		resolved:            resolved,
+		pool:                map[string][]connection{},
+	}
+
+	go func() {
+		// TODO: real resolution :P
+		defer close(resolved)
+		roundTripper := factory.New(RoundTripperOptions{})
+		conn := connection{
+			addr: hostPort,
+			conn: roundTripper,
+		}
+		pool.mu.Lock()
+		pool.conns = []connection{conn}
+		pool.pool[hostPort] = []connection{conn}
+		pool.mu.Unlock()
+	}()
+
+	return pool
+}
+
+func (t *transportPool) RoundTrip(request *http.Request) (*http.Response, error) {
+	return t.getRoundTripper().RoundTrip(request)
+}
+
+func (t *transportPool) getRoundTripper() http.RoundTripper {
+	t.mu.RLock()
+	conns := t.conns
+	t.mu.RUnlock()
+
+	if conns == nil {
+		// NB: if resolver returns no addresses, that should
+		//     be represented via empty but non-nil conns...
+		<-t.resolved
+		t.mu.RLock()
+		conns = t.conns
+		t.mu.RUnlock()
+	}
+
+	if len(conns) == 0 {
+		return noAddressRoundTripper{}
+	}
+	return t.pick(conns)
+}
+
+func (t *transportPool) pick(conns []connection) http.RoundTripper {
+	// TODO implement me
+	return conns[0].conn
+}
+
+type connection struct {
+	addr string
+	conn http.RoundTripper
+}
+
+type RoundTripperFactory interface {
+	New(RoundTripperOptions) http.RoundTripper
+}
+
+type RoundTripperOptions struct {
+	// TODO
+}
+
+type simpleFactory struct{}
+
+func (s simpleFactory) New(_ RoundTripperOptions) http.RoundTripper {
+	// TODO: make this real (below is just copied from http.DefaultTransport for now...)
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+type noAddressRoundTripper struct{}
+
+func (n noAddressRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	// TODO: probably want more useful info in this error message
+	return nil, fmt.Errorf("failed to resolve hostname")
+}


### PR DESCRIPTION
This is hopefully a reasonable starting point to discuss the basic design of the client/transport that this repo will provide. This proposes using a hierarchy of transports that is three levels deep.

Most of the "real" stuff we want to do is all TODO. This has a very basic `NewClient` API that accepts options (no options defined yet...). The options would be how users configure the client, providing custom resolvers, balancers, health-checkers, etc...

This also creates a very rudimentary implementation (more of an outline really) of the main two levels of the transport hierarchy: the main transport, and a "connection pool" transport that manages requests for a single target domain.

This will all have to be refactored as features are implemented. None of the transport implementation needs to be considered "real": this was mostly to get a conversation started about the architecture so far.

---

I think design question number 1 is: "Should this provide a complete HTTP client, usable for requests to any/all domains? Or should it instead provide a client for a particular service, which returns errors if used with requests to the wrong domain?"

What's in this branch is the former, thus necessitating the "top-level" transport. But configuration for some of the stuff we're talking about is likely to often be "per service". So trying to provide a "panacea" client, all in one instance, could mean either complicated configuration (to expose ability to configure certain things _per domain_) or error-prone to use (e.g. user creates two clients with different configs but then uses the wrong one with a particular HTTP request).

We could pivot to the latter approach, where you instead have something akin to a `Dial` function, that returns a client that is usable just for the given host/domain. That way, there's no need to support multiple configurations (based on target domain) in a single client, and we can even fail-fast if the client is used to send a request to the wrong host. But it would be counter to the way `net/http` clients usually work, so perhaps too non-intuitive for Go developers?