### PR TITLE
Add Close function

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package httpbalancer
+package httplb
 
 import (
 	"context"
@@ -237,6 +237,20 @@ func NewClient(options ...ClientOption) *http.Client {
 		Transport:     newTransport(&opts),
 		CheckRedirect: opts.redirectFunc,
 	}
+}
+
+// Close closes the given HTTP client, releasing any resources and stopping
+// any associated background goroutines.
+//
+// If the given client was not created using NewClient, this will return an
+// error.
+func Close(client *http.Client) error {
+	transport, ok := client.Transport.(*mainTransport)
+	if !ok {
+		return errors.New("client not created by this package")
+	}
+	transport.close()
+	return nil
 }
 
 // Prewarm pre-warms the given HTTP client, making sure that any targets

--- a/client_test.go
+++ b/client_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package httpbalancer
+package httplb
 
 import (
 	"context"
@@ -52,11 +52,18 @@ func TestNewClient(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	cl := NewClient()
+	client := NewClient()
+	t.Cleanup(func() {
+		err := Close(client)
+		require.NoError(t, err)
+	})
+	err = Prewarm(ctx, client)
+	require.NoError(t, err)
+
 	url := fmt.Sprintf("http://%s/foo", listener.Addr().String())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
-	resp, err := cl.Do(req)
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer func() {
 		err := resp.Body.Close()

--- a/doc.go
+++ b/doc.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package httpbalancer provides http.Client instances that are suitable
+// Package httplb provides http.Client instances that are suitable
 // for use for server-to-server communications, like RPC. This adds features
 // on top of the standard net/http library for name/address resolution,
 // health checking, connection management and subsetting, and load balancing.
 // It also provides more suitable defaults and much simpler support for
 // HTTP/2 over plaintext.
-package httpbalancer
+package httplb


### PR DESCRIPTION
This provides a `Close` function, for shutting down a client and releasing any associated resources.

While in here, I renamed the package to `httplb`.

This is the start of TCN-1877. There are still a few TODOs to make sure that everything is actually stopped when `Close` returns.