### PR TITLE
Use http.ErrUseLastResponse for default redirect handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,7 +31,6 @@ var (
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
-	errNoRedirects = errors.New("not following redirects")
 )
 
 // ClientOption is an option used to customize the behavior of an HTTP client.


### PR DESCRIPTION
Instead of failing the request on a redirect, we can just let the caller see the redirect response. This is what is actually recommended in Connect docs [here](https://connect.build/docs/go/deployment#timeouts-and-connection-pools).