### PR TITLE
Add support for custom round tripper factories and for h2c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/net v0.10.0
 	golang.org/x/sync v0.2.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
 golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
+golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httplb
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+// RoundTripperFactory is used to create "leaf" transports in the client. A leaf transport
+// handles requests to a single resolved address.
+type RoundTripperFactory interface {
+	// New creates a new [http.RoundTripper] for requests using the given scheme to the
+	// given host, configured using the given options.
+	New(scheme, target string, options RoundTripperOptions) RoundTripperResult
+}
+
+// RoundTripperResult represents a "leaf" transport created by a RoundTripperFactory.
+type RoundTripperResult struct {
+	// RoundTripper is the actual round-tripper that handles requests.
+	RoundTripper http.RoundTripper
+	// Scheme, if non-empty, is the scheme to use for requests to RoundTripper. This
+	// replaces the request's original scheme. This is useful when a custom scheme
+	// is used to trigger a custom transport, but the underlying RoundTripper still
+	// expects a non-custom scheme, such as "http" or "https".
+	Scheme string
+	// Close is an optional function that will be called (if non-nil) when this
+	// round-tripper is no longer needed.
+	Close func()
+	// PreWarm is an optional function that will be called (if non-nil) to
+	// eagerly establish connections and perform any other checks so that there
+	// are no delays or unexpected errors incurred by the first HTTP request.
+	PreWarm func(ctx context.Context, addr string) error
+}
+
+// RoundTripperOptions defines the options used to create a round-tripper.
+type RoundTripperOptions struct {
+	// DialFunc should be used by the round-tripper establish network connections.
+	DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+	// ProxyFunc should be used to control HTTP proxying behavior. If the function
+	// returns a non-nil URL for a given request, that URL represents the HTTP proxy
+	// that should be used.
+	ProxyFunc func(*http.Request) (*url.URL, error)
+	// ProxyHeadersFunc should be called, if non-nil, before sending a CONNECT
+	// request, to query for headers to add to that request. If it returns an
+	// error, the round-trip operation should fail immediately with that error.
+	ProxyHeadersFunc func(ctx context.Context, proxyURL *url.URL, target string) (http.Header, error)
+	// MaxResponseHeaderBytes configures the maximum size of the response status
+	// line and response headers.
+	MaxResponseHeaderBytes int64
+	// IdleConnTimeout, if non-zero, is used to expire idle network connections.
+	IdleConnTimeout time.Duration
+	// TLSClientConfig, is present, provides custom TLS configuration for use
+	// with secure ("https") servers.
+	TLSClientConfig *tls.Config
+	// TLSHandshakeTimeout configures the maximum time allowed for a TLS handshake
+	// to complete.
+	TLSHandshakeTimeout time.Duration
+	// KeepWarm indicates that the round-tripper should try to keep a ready
+	// network connection open to reduce any delays in processing a request.
+	KeepWarm bool
+}
+
+type simpleFactory struct{}
+
+func (s simpleFactory) New(_, _ string, opts RoundTripperOptions) RoundTripperResult {
+	transport := &http.Transport{
+		Proxy:                  opts.ProxyFunc,
+		GetProxyConnectHeader:  opts.ProxyHeadersFunc,
+		DialContext:            opts.DialFunc,
+		ForceAttemptHTTP2:      true,
+		MaxIdleConns:           1,
+		MaxIdleConnsPerHost:    1,
+		IdleConnTimeout:        opts.IdleConnTimeout,
+		TLSHandshakeTimeout:    opts.TLSHandshakeTimeout,
+		TLSClientConfig:        opts.TLSClientConfig,
+		MaxResponseHeaderBytes: opts.MaxResponseHeaderBytes,
+		ExpectContinueTimeout:  1 * time.Second,
+	}
+	// no way to populate pre-warm function since http.Transport doesn't provide
+	// any way to do that :(
+	return RoundTripperResult{RoundTripper: transport, Close: transport.CloseIdleConnections}
+}
+
+type h2cFactory struct{}
+
+func (s h2cFactory) New(_, _ string, opts RoundTripperOptions) RoundTripperResult {
+	// We can't support all round tripper options with H2C.
+	transport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return defaultDialer.DialContext(ctx, network, addr)
+		},
+		// We don't bother setting the TLS config, because h2c is plain-text only
+		//TLSClientConfig:   opts.TLSClientConfig,
+		MaxHeaderListSize: uint32(opts.MaxResponseHeaderBytes),
+	}
+	return RoundTripperResult{RoundTripper: transport, Scheme: "http", Close: transport.CloseIdleConnections}
+}

--- a/transport.go
+++ b/transport.go
@@ -16,11 +16,9 @@ package httplb
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -35,55 +33,6 @@ var (
 	errResolverReturnedNoAddresses = errors.New("resolver returned no addresses")
 	errTransportIsClosed           = errors.New("transport is closed")
 )
-
-// RoundTripperFactory is used to create "leaf" transports in the client. A leaf transport
-// handles requests to a single resolved address.
-type RoundTripperFactory interface {
-	// New creates a new [http.RoundTripper] for requests using the given scheme to the
-	// given host, configured using the given options.
-	New(scheme, target string, options RoundTripperOptions) RoundTripperResult
-}
-
-// RoundTripperResult represents a "leaf" transport created by a RoundTripperFactory.
-type RoundTripperResult struct {
-	// RoundTripper is the actual round-tripper that handles requests.
-	RoundTripper http.RoundTripper
-	// Close is an optional function that will be called (if non-nil) when this
-	// round-tripper is no longer needed.
-	Close func()
-	// PreWarm is an optional function that will be called (if non-nil) to
-	// eagerly establish connections and perform any other checks so that there
-	// are no delays or unexpected errors incurred by the first HTTP request.
-	PreWarm func(ctx context.Context) error
-}
-
-// RoundTripperOptions defines the options used to create a round-tripper.
-type RoundTripperOptions struct {
-	// DialFunc should be used by the round-tripper establish network connections.
-	DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
-	// ProxyFunc should be used to control HTTP proxying behavior. If the function
-	// returns a non-nil URL for a given request, that URL represents the HTTP proxy
-	// that should be used.
-	ProxyFunc func(*http.Request) (*url.URL, error)
-	// ProxyHeadersFunc should be called, if non-nil, before sending a CONNECT
-	// request, to query for headers to add to that request. If it returns an
-	// error, the round-trip operation should fail immediately with that error.
-	ProxyHeadersFunc func(ctx context.Context, proxyURL *url.URL, target string) (http.Header, error)
-	// MaxResponseHeaderBytes configures the maximum size of the response status
-	// line and response headers.
-	MaxResponseHeaderBytes int64
-	// IdleConnTimeout, if non-zero, is used to expire idle network connections.
-	IdleConnTimeout time.Duration
-	// TLSClientConfig, is present, provides custom TLS configuration for use
-	// with secure ("https") servers.
-	TLSClientConfig *tls.Config
-	// TLSHandshakeTimeout configures the maximum time allowed for a TLS handshake
-	// to complete.
-	TLSHandshakeTimeout time.Duration
-	// KeepWarm indicates that the round-tripper should try to keep a ready
-	// network connection open to reduce any delays in processing a request.
-	KeepWarm bool
-}
 
 // TODO: add this info (whatever's relevant/user-visible) to doc.go
 
@@ -205,6 +154,11 @@ func (m *mainTransport) getOrCreatePool(dest target) (*transportPool, error) {
 		return pool, nil
 	}
 
+	schemeConf, ok := m.clientOptions.schemes[dest.scheme]
+	if !ok {
+		return nil, fmt.Errorf("unsupported URL scheme %q", dest.scheme)
+	}
+
 	targetOpts := m.clientOptions.optionsForTarget(dest)
 	if targetOpts == nil {
 		return nil, fmt.Errorf("client does not allow requests to unconfigured target %s", dest)
@@ -229,7 +183,7 @@ func (m *mainTransport) getOrCreatePool(dest target) (*transportPool, error) {
 	// explicitly configured targets are kept warm
 	_, opts.KeepWarm = m.clientOptions.computedTargetOptions[dest]
 
-	pool = newTransportPool(m.rootCtx, dest, applyTimeout, simpleFactory{}, opts, m.clientOptions.resourceLeakCallback)
+	pool = newTransportPool(m.rootCtx, dest, applyTimeout, schemeConf, opts, m.clientOptions.resourceLeakCallback)
 	var activity chan struct{}
 	if !opts.KeepWarm {
 		activity = make(chan struct{}, 1)
@@ -381,6 +335,7 @@ func newTransportPool(
 		result := factory.New(dest.scheme, addr, opts)
 		conn := &connection{
 			addr:    addr,
+			scheme:  result.Scheme,
 			conn:    result.RoundTripper,
 			close:   result.Close,
 			prewarm: result.PreWarm,
@@ -406,6 +361,16 @@ func (t *transportPool) RoundTrip(request *http.Request) (*http.Response, error)
 		request = request.WithContext(ctx)
 	}
 	conn.activeRequests.Add(1)
+
+	// rewrite request if necessary
+	if (conn.scheme != "" && conn.scheme != request.URL.Scheme) || conn.addr != request.URL.Host {
+		request = request.Clone(request.Context())
+		if conn.scheme != "" {
+			request.URL.Scheme = conn.scheme
+		}
+		request.URL.Host = conn.addr
+	}
+
 	resp, err := conn.conn.RoundTrip(request)
 	if err != nil {
 		return nil, err
@@ -470,10 +435,11 @@ func (t *transportPool) prewarm(ctx context.Context) error {
 	//       been closed (if racing with a call to close the pool)
 	grp, grpCtx := errgroup.WithContext(ctx)
 	for _, conn := range conns {
+		// TODO: do we need to warmup *every* address?
 		conn := conn
 		if conn.prewarm != nil {
 			grp.Go(func() error {
-				return conn.prewarm(grpCtx)
+				return conn.prewarm(grpCtx, conn.addr)
 			})
 		}
 	}
@@ -498,10 +464,11 @@ func (t *transportPool) close() {
 }
 
 type connection struct {
+	scheme  string
 	addr    string
 	conn    http.RoundTripper
 	close   func()
-	prewarm func(context.Context) error
+	prewarm func(context.Context, string) error
 
 	activeRequests atomic.Int32
 }
@@ -516,27 +483,6 @@ func roundTripperOptionsFrom(opts *targetOptions) RoundTripperOptions {
 		TLSClientConfig:        opts.tlsClientConfig,
 		TLSHandshakeTimeout:    opts.tlsHandshakeTimeout,
 	}
-}
-
-type simpleFactory struct{}
-
-func (s simpleFactory) New(_, _ string, opts RoundTripperOptions) RoundTripperResult {
-	transport := &http.Transport{
-		Proxy:                  opts.ProxyFunc,
-		GetProxyConnectHeader:  opts.ProxyHeadersFunc,
-		DialContext:            opts.DialFunc,
-		ForceAttemptHTTP2:      true,
-		MaxIdleConns:           1,
-		MaxIdleConnsPerHost:    1,
-		IdleConnTimeout:        opts.IdleConnTimeout,
-		TLSHandshakeTimeout:    opts.TLSHandshakeTimeout,
-		TLSClientConfig:        opts.TLSClientConfig,
-		MaxResponseHeaderBytes: opts.MaxResponseHeaderBytes,
-		ExpectContinueTimeout:  1 * time.Second,
-	}
-	// no way to populate pre-warm function since http.Transport doesn't provide
-	// any way to do that :(
-	return RoundTripperResult{RoundTripper: transport, Close: transport.CloseIdleConnections}
 }
 
 func addCompletionHook(req *http.Request, resp *http.Response, whenComplete func(), resourceLeakCallback func(req *http.Request, resp *http.Response)) {


### PR DESCRIPTION
This lets callers customize the client by mapping URL schemes to custom `RoundTripperFactory` values.

This same mechanism is used to support H2C as a URL scheme, to trigger HTTP/2 over plaintext.

Resolves TCN-1861 and TCN-1862.
