### PR TITLE
Add balancer interfaces

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -1,0 +1,84 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package balancer
+
+import (
+	"context"
+
+	"github.com/bufbuild/go-http-balancer/balancer/conn"
+	"github.com/bufbuild/go-http-balancer/balancer/picker"
+	"github.com/bufbuild/go-http-balancer/resolver"
+)
+
+// Factory is what creates Balancer instances. A single balancer acts on behalf of a
+// single target (schema and host:port). So an HTTP client can be configured with a
+// Factory, to create a Balancer for each target.
+type Factory interface {
+	// New creates a new balancer.
+	//
+	// As results come in from a corresponding resolver for the given scheme and
+	// hostPort, the balancer's OnResolve method is called. It is the balancer's
+	// job to use this information to decide what connections to create, by calling
+	// the given ConnPool's NewConn and RemoveConn methods. It must also call the
+	// ConnPool's UpdatePicker method whenever it should use a different picker.
+	// The method must be called at least once, with the initial picker. Whether or
+	// not subsequent calls are needed depend on the balancer implementation. For
+	// example, a simple picker that is not coupled to the balancer implementation
+	// and its internals may need to be rebuilt and updated every time connections
+	// change state. But a picker that is highly coupled to the balancer
+	// implementation may have all the information it needs by inspecting balancer
+	// internals and thus never need to be recreated or updated.
+	New(ctx context.Context, scheme, hostPort string, pool ConnPool) Balancer
+}
+
+// Balancer is the component that handles load balancing. It must make decisions
+// about what connections to maintain as it gets updated addresses from a
+// resolver. It also provides the Picker, which is what makes decisions about
+// which connection to use for a given request.
+type Balancer interface {
+	// OnResolve reconciles the current state of connections with the given set
+	// of addresses, by creating or removing connections using the ConnPool
+	// provided when the balancer was created.
+	OnResolve([]resolver.Address)
+	// OnResolveError handles resolver errors. Its main responsibility should be
+	// to create the initial picker for the associated ConnPool if it's the very
+	// first thing received from a resolver. This unblocks requests on the pool,
+	// so they can fail with a resolver error.
+	OnResolveError(error)
+	Close() error
+}
+
+// ConnPool is the interface through which a Balancer interacts with the HTTP
+// client, creating and destroying "connections" (leaf transports) as needed.
+type ConnPool interface {
+	// NewConn creates a new connection to the given address, with the given
+	// attributes. Does not block for network connections to be established.
+	NewConn(resolver.Address) conn.Conn
+	// RemoveConn removes the given connection. The balancer must arrange for
+	// the picker to not return the given connection for any operations after
+	// this is called. It may, for example, call UpdatePicker with a new picker
+	// that doesn't even consider this connection before calling RemoveConn.
+	RemoveConn(conn.Conn)
+	// UpdatePicker updates the picker that the connection pool should use. The
+	// picker is what selects a connection from the set of existing connections
+	// (ones created with NewConn, excluding ones removed with RemoveConn). This
+	// is what can implement algorithms like round-robin, least-loaded,
+	// power-of-two, EWMA, etc.
+	//
+	// The balancer *must* call this at least once. The balancer should call it
+	// as soon as possible after receiving results from a resolver. Operations
+	// will block until the first time it is called.
+	UpdatePicker(picker.Picker)
+}

--- a/balancer/conn/conn.go
+++ b/balancer/conn/conn.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conn
+
+import (
+	"net/http"
+
+	"github.com/bufbuild/go-http-balancer/attrs"
+	"github.com/bufbuild/go-http-balancer/resolver"
+)
+
+// Conn represents a connection to a resolved address. It is a *logical*
+// connection. It may actually be represented by zero or more physical
+// connections (i.e. sockets).
+type Conn interface {
+	// Address is the address used by this connection.
+	Address() resolver.Address
+	// UpdateAttributes updates the connection's address to have the given attributes.
+	UpdateAttributes(attributes attrs.Attributes)
+	// RoundTripper allows sending an HTTP request on this connection.
+	RoundTripper() http.RoundTripper
+}
+
+// Connections represents a read-only set of connections.
+type Connections interface {
+	// Len returns the total number of connections in the set.
+	Len() int
+	// Get returns the connection at index i.
+	Get(i int) Conn
+}

--- a/balancer/connmanager/connmanager.go
+++ b/balancer/connmanager/connmanager.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"context"
+
+	"github.com/bufbuild/go-http-balancer/balancer/conn"
+	"github.com/bufbuild/go-http-balancer/resolver"
+)
+
+// Factory is used to build ConnManager instances.
+type Factory interface {
+	// New creates a new ConnManager for the given scheme and host:port.
+	// It should release any resources (including stopping goroutines) if either
+	// the given context is cancelled or its Close() method is called.
+	//
+	// The ConnManager may use the given functions to create and remove connections.
+	New(ctx context.Context, scheme, hostPort string, updateConns ConnUpdater) ConnManager
+}
+
+// ConnUpdater is a function that adds connections for the given newAddrs, removes
+// the given removeConns, and returns the newly created connections (in the same
+// order as given in newAddrs).
+type ConnUpdater func(newAddrs []resolver.Address, removeConns []conn.Conn) (added []conn.Conn)
+
+// ConnManager encapsulates part of the logic of a balancer.Balancer. Its
+// responsibility is deciding what connections to create or remove as results
+// come in from a resolver. It must decide both how many connections to maintain
+// and to which resolved addresses connections will be established.
+type ConnManager interface {
+	// ReconcileAddresses is called when new results are available from a resolver.
+	// The ConnManager should create and remove connections to keep the current set
+	// of connections reconciled with the given latest results.
+	//
+	// Balancers created using a factory from balancer.NewFactory will never call
+	// this concurrently. So if the ConnManager implementation does not need to
+	// create other goroutines, the data structures it uses in this method do not
+	// need to be thread-safe.
+	ReconcileAddresses([]resolver.Address)
+	// Close releases all resources (including stopping background goroutines if
+	// any). All resources should be freed when this method returns.
+	Close() error
+}

--- a/balancer/connmanager/default_connmanager.go
+++ b/balancer/connmanager/default_connmanager.go
@@ -1,0 +1,33 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"github.com/bufbuild/go-http-balancer/resolver"
+)
+
+// NewFactory returns a Factory that consults the given
+// Subsetter to decide on the subset of addresses to use.
+func NewFactory(_ Subsetter) Factory {
+	// TODO: implement me!
+	return nil
+}
+
+type Subsetter interface {
+	// ComputeSubset returns a static subset of the given addresses. It is
+	// allowed to return duplicates, if it wants to return more addresses than
+	// are actually given.
+	ComputeSubset([]resolver.Address) []resolver.Address
+}

--- a/balancer/default_balancer.go
+++ b/balancer/default_balancer.go
@@ -1,0 +1,88 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package balancer
+
+import (
+	"context"
+
+	"github.com/bufbuild/go-http-balancer/balancer/connmanager"
+	"github.com/bufbuild/go-http-balancer/balancer/healthchecker"
+	"github.com/bufbuild/go-http-balancer/balancer/picker"
+)
+
+// NewFactory returns a new balancer factory. If no options are given,
+// the default behavior is as follows:
+// * No subsetting. Connections are created for all resolved addresses.
+// * No health checks. All connections are considered usable.
+// * Round-robin picker.
+func NewFactory(opts ...NewFactoryOption) Factory {
+	factory := &defaultBalancerFactory{}
+	for _, opt := range opts {
+		opt.apply(factory)
+	}
+	return factory
+}
+
+type NewFactoryOption interface {
+	apply(balancer *defaultBalancerFactory)
+}
+
+// WithConnManager configures a balancer factory to use the given
+// connmanager.Factory. It will be used to create a connmanager.ConnManager
+// for each Balancer. The ConnManager is what decides what connections to
+// create or remove.
+func WithConnManager(connManager connmanager.Factory) NewFactoryOption {
+	return newFactoryOption(func(factory *defaultBalancerFactory) {
+		factory.connManager = connManager
+	})
+}
+
+// WithPicker configures a balancer factory to use the given picker.Factory.
+// A new picker will be created every time the set of usable connections
+// changes for a given balancer.
+func WithPicker(picker picker.Factory) NewFactoryOption {
+	return newFactoryOption(func(factory *defaultBalancerFactory) {
+		factory.picker = picker
+	})
+}
+
+// WithHealthChecks configures a balancer factory to use the given health
+// checker. This provides details about which resolved addresses are
+// healthy or not. The given oracle is used to interpret the health check
+// results and decide which connections are usable.
+func WithHealthChecks(checker healthchecker.Checker, oracle healthchecker.UsabilityOracle) NewFactoryOption {
+	return newFactoryOption(func(factory *defaultBalancerFactory) {
+		factory.healthChecker = checker
+		factory.usabilityOracle = oracle
+	})
+}
+
+type newFactoryOption func(factory *defaultBalancerFactory)
+
+func (o newFactoryOption) apply(factory *defaultBalancerFactory) {
+	o(factory)
+}
+
+type defaultBalancerFactory struct {
+	connManager     connmanager.Factory
+	picker          picker.Factory
+	healthChecker   healthchecker.Checker
+	usabilityOracle healthchecker.UsabilityOracle
+}
+
+func (f *defaultBalancerFactory) New(_ context.Context, _, _ string, _ ConnPool) Balancer {
+	// TODO: implement me!
+	return nil
+}

--- a/balancer/healthchecker/healthchecker.go
+++ b/balancer/healthchecker/healthchecker.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthchecker
+
+import (
+	"context"
+	"io"
+
+	"github.com/bufbuild/go-http-balancer/balancer/conn"
+)
+
+//nolint:gochecknoglobals
+var (
+	DefaultUsabilityOracle = func(allCons conn.Connections, state func(conn.Conn) HealthState) []conn.Conn {
+		length := allCons.Len()
+		usable := make([]conn.Conn, 0, length)
+		for i := 0; i < length; i++ {
+			connection := allCons.Get(i)
+			if state(connection) == HealthStateHealthy {
+				usable = append(usable, connection)
+			}
+		}
+		return usable
+	}
+
+	NoOpChecker Checker = noOpChecker{}
+)
+
+type HealthState int
+
+const (
+	HealthStateUnknown = HealthState(iota)
+	HealthStateHealthy
+	HealthStateDegraded
+	HealthStateUnhealthy
+)
+
+// Checker manages health checks. It creates new checking processes as new
+// connections are created. Each process can be independently stopped.
+type Checker interface {
+	// New creates a new health-checking process for the given connection.
+	// The process should release resources (including stopping any goroutines)
+	// when the given context is cancelled or the returned value is closed.
+	//
+	// The process should use the HealthTracker to record the results of the
+	// health checks.
+	New(context.Context, conn.Conn, HealthTracker) io.Closer
+}
+
+type HealthTracker interface {
+	UpdateHealthState(conn.Conn, HealthState)
+}
+
+// The UsabilityOracle decides which connections are usable. Given the set
+// of all connections and an accessor, for querying the health state of a
+// particular connection, it returns a slice of "usable" connections.
+type UsabilityOracle func(conn.Connections, func(conn.Conn) HealthState) []conn.Conn
+
+type noOpChecker struct{}
+
+func (n noOpChecker) New(_ context.Context, c conn.Conn, tracker HealthTracker) io.Closer {
+	// the no-op checker assumes all connections are healthy
+	tracker.UpdateHealthState(c, HealthStateHealthy)
+	return noOpCloser{}
+}
+
+type noOpCloser struct{}
+
+func (n noOpCloser) Close() error {
+	return nil
+}

--- a/balancer/picker/picker.go
+++ b/balancer/picker/picker.go
@@ -1,0 +1,47 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package picker
+
+import (
+	"net/http"
+
+	"github.com/bufbuild/go-http-balancer/balancer/conn"
+)
+
+// Picker implements connection selection. For a given request, it returns
+// the connection to use. It also returns a callback that, if non-nil, will
+// be invoked when the operation is complete. (This happens when the HTTP
+// response is returned and its body fully consumed or closed.) Such a
+// callback can be used, for example, to track the number of active requests
+// for a least-loaded implementation.
+type Picker interface {
+	Pick(req *http.Request) (conn conn.Conn, whenDone func(), err error)
+}
+
+// Factory creates new Picker instances.
+type Factory interface {
+	// New creates a new picker that will select a connection from the given
+	// set. The previous picker is provided so that successive "generations"
+	// of pickers can share state. This is necessary for something like a
+	// least-loaded algorithm, where tracking the number of active operations
+	// per connection needs to persist from one picker to the next. Note that
+	// the previous picker may still be in use, concurrently, while the factory
+	// is creating the new one, and even for some small amount of time after this
+	// method returns. Also, operations might be started with the previous picker
+	// but not completed until after the new picker is put in use. Picker
+	// factory implementations need to use care for thread-safety when pickers
+	// need to share state.
+	New(prev Picker, allConns conn.Connections) Picker
+}


### PR DESCRIPTION
This creates numerous sub-directories and adds all of the interfaces and stubs out some functions and such from the [balancer design](https://www.notion.so/bufbuild/Balancer-design-8f3ede93305b46c5a8331cd30a724fa5).

This should be enough structure in place to start working on fleshing out the stubs and adding implementations of the various interfaces. We'll need:
1. Default balancer impl
2. Default connection manager impl
   * And at least two subsetters: a dumb "use all", and a smarter one (like rendezvous-hash)
4. Default health checker impl
6. Default pickers: round-robin, random, least-loaded, and power-of-two

Once we have the first and at least one picker, we'll have enough to actually incorporate the balancer into the transport implementations in "httplb".

Resolves TCN-1907