### PR TITLE
Overhaul a few of things for consistency

### DIFF
--- a/balancer/default_balancer.go
+++ b/balancer/default_balancer.go
@@ -48,6 +48,8 @@ func NewFactory(opts ...NewFactoryOption) Factory {
 	return factory
 }
 
+// NewFactoryOption is an option for configuring the behavior of a Factory
+// return from NewFactory.
 type NewFactoryOption interface {
 	apply(balancer *defaultBalancerFactory)
 }
@@ -97,10 +99,10 @@ type defaultBalancerFactory struct {
 
 func (f *defaultBalancerFactory) applyDefaults() {
 	if f.connManager == nil {
-		f.connManager = connmanager.NewFactory(connmanager.UseAll())
+		f.connManager = connmanager.NewFactory()
 	}
 	if f.picker == nil {
-		f.picker = picker.ChooseFirstFactory // TODO: use round-robin once implemented
+		f.picker = picker.RoundRobinFactory
 	}
 	if f.healthChecker == nil {
 		f.healthChecker = healthchecker.NoOpChecker


### PR DESCRIPTION
This overhauls `connmanager.NewFactory` to have an API shape more like `balancer.NewFactory`. It also changes the factory for the "use all" subsetter from a function a var (since the impl is immutable and unparameterized).

Finally, now that you landed the round-robin picker, that is used as the default picker for `balancer.NewFactory`.