### PR TITLE
Allow balancer to call ResolveNow

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -95,4 +95,9 @@ type ConnPool interface {
 	// It usually means some minimum number of connections are healthy and
 	// available for use.
 	UpdatePicker(picker picker.Picker, isWarm bool)
+	// ResolveNow requests that addresses be re-resolved immediately. This can be
+	// used by the balancer if it thinks the addresses it has may be out of date
+	// (such as if too many are failing health checks, which could be due to some
+	// addresses no longer providing the desired service).
+	ResolveNow()
 }

--- a/balancer/balancertesting/balancertesting.go
+++ b/balancer/balancertesting/balancertesting.go
@@ -162,6 +162,9 @@ func (p *FakeConnPool) UpdatePicker(picker picker.Picker, isWarm bool) {
 	}
 }
 
+// ResolveNow implements the balancer.ConnPool interface. It is a no-op.
+func (p *FakeConnPool) ResolveNow() {}
+
 // SnapshotConns returns a snapshot of the current active connections. This will
 // include all connections created via NewConn but not yet removed via RemoveConn.
 func (p *FakeConnPool) SnapshotConns() conn.Set {

--- a/httplb/transport.go
+++ b/httplb/transport.go
@@ -348,7 +348,7 @@ type transportPool struct {
 	roundTripperFactory RoundTripperFactory // +checklocksignore: mu is not required, it just happens to be held always.
 	roundTripperOptions RoundTripperOptions // +checklocksignore: mu is not required, it just happens to be held always.
 	pickerInitialized   chan struct{}
-	resolver            io.Closer
+	resolver            resolver.Resolver
 	balancer            balancer.Balancer
 	closeComplete       chan struct{}
 	onClose             func()
@@ -486,6 +486,10 @@ func (t *transportPool) UpdatePicker(picker picker.Picker, isWarm bool) {
 	if isWarm {
 		t.warmCond.Broadcast()
 	}
+}
+
+func (t *transportPool) ResolveNow() {
+	t.resolver.ResolveNow()
 }
 
 func (t *transportPool) RoundTrip(request *http.Request) (*http.Response, error) {


### PR DESCRIPTION
This adds a method to the `ConnPool` interface, which is how a balancer interacts with its associated transport/connection pool. The new method is to request that the resolver immediately re-resolve addresses. This simply calls through to the resolver's newly added `ResolveNow` method.