### PR TITLE
Fix heap update operation for least-loaded picker

### DIFF
--- a/picker/leastloaded.go
+++ b/picker/leastloaded.go
@@ -135,7 +135,7 @@ func (h *leastLoadedConnHeap) update(allConns conn.Conns) {
 	for i, l := 0, allConns.Len(); i < l; i++ {
 		newMap[allConns.Get(i)] = struct{}{}
 	}
-	j := 0
+	j := 0 //nolint:varnamelen
 	slice := *h
 	// Remove items from slice that aren't in the new set of conns,
 	// compacting the slice as we go.

--- a/picker/leastloaded_heap_test.go
+++ b/picker/leastloaded_heap_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package picker
 
 import (

--- a/picker/leastloaded_heap_test.go
+++ b/picker/leastloaded_heap_test.go
@@ -1,0 +1,186 @@
+package picker
+
+import (
+	"testing"
+
+	"github.com/bufbuild/httplb/conn"
+	"github.com/bufbuild/httplb/internal/conns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeastLoadedConnHeap(t *testing.T) {
+	t.Parallel()
+	heap := newConnHeap(conns.FromSlice([]conn.Conn{
+		dummyConn{id: "a"},
+		dummyConn{id: "b"},
+		dummyConn{id: "c"},
+		dummyConn{id: "d"},
+		dummyConn{id: "e"},
+		dummyConn{id: "f"},
+	}))
+	counts := map[string]uint64{
+		"a": 0,
+		"b": 0,
+		"c": 0,
+		"d": 0,
+		"e": 0,
+		"f": 0,
+	}
+	verifyHeap(t, heap, counts)
+
+	// Note: order may not be intuitive, due to how
+	// nodes in the heap are sifted up and down as an item
+	// is popped, but it is deterministic.
+
+	// No repeats since they all have weight zero.
+	verifyPicks(t, heap, counts, "abdecf")
+	// Now they all have weight one, so they all repeat. But
+	// we don't see any item a third time until we've seen
+	// all of 'em 2x.
+	verifyPicks(t, heap, counts, "fdabce")
+
+	verifyReleases(t, heap, counts, "aabb")
+
+	// Now a and b have a load of zero, but the others have load 2.
+	// So we'll pick them next.
+	verifyPicks(t, heap, counts, "abba")
+
+	snapshot := snapshotHeap(heap)
+	// Update state with new connections. We should forget
+	// a, b, c, and d and add g and h.
+	heap.update(conns.FromSlice([]conn.Conn{
+		dummyConn{id: "e"},
+		dummyConn{id: "f"},
+		dummyConn{id: "g"},
+		dummyConn{id: "h"},
+	}))
+	counts = map[string]uint64{
+		"e": 2,
+		"f": 2,
+		"g": 0,
+		"h": 0,
+	}
+	verifyHeap(t, heap, counts)
+
+	// Releasing items no longer present has no impact.
+	heap.release(snapshot["a"])
+	heap.release(snapshot["b"])
+	heap.release(snapshot["c"])
+	heap.release(snapshot["a"])
+	verifyHeap(t, heap, counts)
+
+	// g and h have less load, so we favor them.
+	verifyPicks(t, heap, counts, "hggh")
+	// Now everything has load == 2. So next four picks sees
+	// each of the four items.
+	verifyPicks(t, heap, counts, "hefg")
+
+	// No-op update
+	heap.update(conns.FromSlice([]conn.Conn{
+		dummyConn{id: "h"},
+		dummyConn{id: "g"},
+		dummyConn{id: "f"},
+		dummyConn{id: "e"},
+	}))
+	verifyHeap(t, heap, counts)
+
+	// Update that must grow backing slice
+	heap.update(conns.FromSlice([]conn.Conn{
+		dummyConn{id: "a"},
+		dummyConn{id: "b"},
+		dummyConn{id: "c"},
+		dummyConn{id: "d"},
+		dummyConn{id: "e"},
+		dummyConn{id: "f"},
+		dummyConn{id: "g"},
+		dummyConn{id: "h"},
+		dummyConn{id: "i"},
+		dummyConn{id: "j"},
+		dummyConn{id: "k"},
+		dummyConn{id: "l"},
+	}))
+	counts = map[string]uint64{
+		"a": 0,
+		"b": 0,
+		"c": 0,
+		"d": 0,
+		"e": 3,
+		"f": 3,
+		"g": 3,
+		"h": 3,
+		"i": 0,
+		"j": 0,
+		"k": 0,
+		"l": 0,
+	}
+	verifyHeap(t, heap, counts)
+}
+
+func verifyPicks(t *testing.T, heap *leastLoadedConnHeap, counts map[string]uint64, ids string) {
+	t.Helper()
+	for _, ch := range ids {
+		id := string(ch)
+		item := heap.acquire(0)
+		require.Equal(t, id, connId(item.conn))
+		counts[id]++
+		verifyHeap(t, heap, counts)
+	}
+}
+
+func verifyReleases(t *testing.T, heap *leastLoadedConnHeap, counts map[string]uint64, ids string) {
+	t.Helper()
+	for _, ch := range ids {
+		id := string(ch)
+		release(t, heap, id)
+		counts[id]--
+		verifyHeap(t, heap, counts)
+	}
+}
+
+func release(t *testing.T, heap *leastLoadedConnHeap, id string) {
+	for _, item := range *heap {
+		if connId(item.conn) == id {
+			heap.release(item)
+			return
+		}
+	}
+	t.Fatalf("item %s not found in heap", id)
+}
+
+func snapshotHeap(heap *leastLoadedConnHeap) map[string]*leastLoadedConnItem {
+	snapshot := make(map[string]*leastLoadedConnItem, len(*heap))
+	for _, item := range *heap {
+		snapshot[connId(item.conn)] = item
+	}
+	return snapshot
+}
+
+func verifyHeap(t *testing.T, heap *leastLoadedConnHeap, counts map[string]uint64) {
+	t.Helper()
+	for i, item := range *heap {
+		require.Equal(t, i, item.index)
+		count, ok := counts[connId(item.conn)]
+		require.True(t, ok)
+		require.Equal(t, count, item.load)
+		if i > 0 {
+			// heap invariant
+			parent := (i - 1) / 2
+			require.LessOrEqual(t, (*heap)[parent].load, item.load)
+		}
+	}
+	backingArray := (*heap)[:cap(*heap)]
+	for i := len(*heap); i < len(backingArray); i++ {
+		// make sure everything else in the backing array, after
+		// the end of the heap, is cleared and not pinning any item
+		require.Nil(t, backingArray[i])
+	}
+}
+
+type dummyConn struct {
+	conn.Conn
+	id string
+}
+
+func connId(cn conn.Conn) string {
+	return cn.(dummyConn).id
+}

--- a/picker/leastloaded_heap_test.go
+++ b/picker/leastloaded_heap_test.go
@@ -121,7 +121,7 @@ func verifyPicks(t *testing.T, heap *leastLoadedConnHeap, counts map[string]uint
 	for _, ch := range ids {
 		id := string(ch)
 		item := heap.acquire(0)
-		require.Equal(t, id, connId(item.conn))
+		require.Equal(t, id, connID(item.conn))
 		counts[id]++
 		verifyHeap(t, heap, counts)
 	}
@@ -137,9 +137,10 @@ func verifyReleases(t *testing.T, heap *leastLoadedConnHeap, counts map[string]u
 	}
 }
 
-func release(t *testing.T, heap *leastLoadedConnHeap, id string) {
+func release(t *testing.T, heap *leastLoadedConnHeap, id string) { //nolint:varnamelen
+	t.Helper()
 	for _, item := range *heap {
-		if connId(item.conn) == id {
+		if connID(item.conn) == id {
 			heap.release(item)
 			return
 		}
@@ -150,7 +151,7 @@ func release(t *testing.T, heap *leastLoadedConnHeap, id string) {
 func snapshotHeap(heap *leastLoadedConnHeap) map[string]*leastLoadedConnItem {
 	snapshot := make(map[string]*leastLoadedConnItem, len(*heap))
 	for _, item := range *heap {
-		snapshot[connId(item.conn)] = item
+		snapshot[connID(item.conn)] = item
 	}
 	return snapshot
 }
@@ -159,7 +160,7 @@ func verifyHeap(t *testing.T, heap *leastLoadedConnHeap, counts map[string]uint6
 	t.Helper()
 	for i, item := range *heap {
 		require.Equal(t, i, item.index)
-		count, ok := counts[connId(item.conn)]
+		count, ok := counts[connID(item.conn)]
 		require.True(t, ok)
 		require.Equal(t, count, item.load)
 		if i > 0 {
@@ -181,6 +182,6 @@ type dummyConn struct {
 	id string
 }
 
-func connId(cn conn.Conn) string {
+func connID(cn conn.Conn) string {
 	return cn.(dummyConn).id
 }


### PR DESCRIPTION
@jchadwick-buf, @lrewega was trying out the least-loaded picker and it panick'ed! 😱

It turns out, the `update` operation -- which reconciles the heap with a new set of connections provided from a resolve -- was iterating from start to finish of the slice, but it would also _change_ the length of the slice while iterating, when it decided it needed to pop an item that should no longer be present.

So the panic was an out-of-bounds slice index. But the iteration is incorrect for more than just that reason: removing an item from the heap that way will also re-order items, to sift things up and down to preserve heap invariants within the slice. So to proceed iterating through the slice means we might visit the same item more than once and fail to visit some items, as their order may have changed underneath us.

So now the logic does a single pass through the slice to remove unneeded items, by simply overwriting them (and setting to nil if necessary). So at the end of the first pass, all that is left in the slice are the items in the new set of connections, compacted to the beginning of the slice (everything after is set to nil). Then we append any new connections. And at the very end, we re-heapify to restore heap invariants after all of that.

This adds a test that is hopefully pretty convincing that it all works correctly now. The test is a sequence of operations, including acquiring connections, releasing them, and updating the resolved set.