### PR TITLE
Implement address family affinity and prefer IPv4 by default

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ var (
 		KeepAlive: 30 * time.Second,
 	}
 	defaultNameTTL  = 5 * time.Minute
-	defaultResolver = resolver.NewDNSResolver(net.DefaultResolver, "ip", defaultNameTTL, resolver.PreferIPv4)
+	defaultResolver = resolver.NewDNSResolver(net.DefaultResolver, resolver.PreferIPv4, defaultNameTTL)
 )
 
 // Client is an HTTP client that supports configurable client-side load

--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ var (
 		KeepAlive: 30 * time.Second,
 	}
 	defaultNameTTL  = 5 * time.Minute
-	defaultResolver = resolver.NewDNSResolver(net.DefaultResolver, "ip", defaultNameTTL)
+	defaultResolver = resolver.NewDNSResolver(net.DefaultResolver, "ip", defaultNameTTL, resolver.PreferIPv4)
 )
 
 // Client is an HTTP client that supports configurable client-side load

--- a/doc.go
+++ b/doc.go
@@ -38,8 +38,9 @@
 //  1. The client will re-resolve addresses in DNS every 5 minutes.
 //     The http.DefaultClient does not re-resolve predictably.
 //
-//  2. The client will route requests in a round-robin fashion to all
-//     addresses returned by the DNS system (both A and AAAA records).
+//  2. The client will route requests in a round-robin fashion to the
+//     addresses returned by the DNS system, preferring A records if
+//     present but using AAAA records if no A records are present,
 //     even with HTTP/2.
 //
 //     This differs from the http.DefaultClient, which will use only a

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -16,6 +16,8 @@ package resolver
 
 import (
 	"context"
+	"encoding/binary"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -23,6 +25,7 @@ import (
 	"github.com/bufbuild/httplb/internal/clocktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/dns/dnsmessage"
 )
 
 func TestResolverTTL(t *testing.T) {
@@ -36,7 +39,7 @@ func TestResolverTTL(t *testing.T) {
 	t.Cleanup(cancel)
 
 	testClock := clocktest.NewFakeClock()
-	resolver := NewDNSResolver(net.DefaultResolver, "ip6", testTTL)
+	resolver := NewDNSResolver(net.DefaultResolver, "ip6", testTTL, AllFamilies)
 	resolver.(*pollingResolver).clock = testClock
 
 	signal := make(chan struct{})
@@ -85,6 +88,124 @@ func TestResolverTTL(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAddressFamilyAffinity(t *testing.T) {
+	t.Parallel()
+
+	ip4Header := dnsmessage.ResourceHeader{
+		Name:  dnsmessage.MustNewName("example.com."),
+		Type:  dnsmessage.TypeA,
+		Class: dnsmessage.ClassINET,
+	}
+	ip6Header := dnsmessage.ResourceHeader{
+		Name:  dnsmessage.MustNewName("example.com."),
+		Type:  dnsmessage.TypeAAAA,
+		Class: dnsmessage.ClassINET,
+	}
+	ip4Address1 := net.ParseIP("10.0.0.100")
+	ip4Address2 := net.ParseIP("10.0.0.101")
+	ip6Address1 := net.ParseIP("fe80::1")
+	ip6Address2 := net.ParseIP("fe80::2")
+	ip4Address1Resource := dnsmessage.Resource{
+		Header: ip4Header,
+		Body:   &dnsmessage.AResource{A: [4]byte(ip4Address1.To4())},
+	}
+	ip4Address2Resource := dnsmessage.Resource{
+		Header: ip4Header,
+		Body:   &dnsmessage.AResource{A: [4]byte(ip4Address2.To4())},
+	}
+	ip6Address1Resource := dnsmessage.Resource{
+		Header: ip6Header,
+		Body:   &dnsmessage.AAAAResource{AAAA: [16]byte(ip6Address1)},
+	}
+	ip6Address2Resource := dnsmessage.Resource{
+		Header: ip6Header,
+		Body:   &dnsmessage.AAAAResource{AAAA: [16]byte(ip6Address2)},
+	}
+
+	// Mixed A/AAAA records
+	mixedDNSResolver := newFakeDNSResolver(t, []dnsmessage.Resource{
+		ip4Address1Resource,
+		ip6Address1Resource,
+		ip4Address2Resource,
+		ip6Address2Resource,
+	})
+	resolver := NewDNSResolver(mixedDNSResolver, "ip", 1, AllFamilies)
+	testResolveAddresses(t, resolver, []net.IP{ip4Address1, ip4Address2, ip6Address1, ip6Address2})
+	resolver = NewDNSResolver(mixedDNSResolver, "ip", 1, PreferIPv4)
+	testResolveAddresses(t, resolver, []net.IP{ip4Address1, ip4Address2})
+	resolver = NewDNSResolver(mixedDNSResolver, "ip", 1, PreferIPv6)
+	testResolveAddresses(t, resolver, []net.IP{ip6Address1, ip6Address2})
+
+	// A records only
+	ip4DNSResolver := newFakeDNSResolver(t, []dnsmessage.Resource{
+		ip4Address1Resource,
+		ip4Address2Resource,
+	})
+	resolver = NewDNSResolver(ip4DNSResolver, "ip", 1, AllFamilies)
+	testResolveAddresses(t, resolver, []net.IP{ip4Address1, ip4Address2})
+	resolver = NewDNSResolver(ip4DNSResolver, "ip", 1, PreferIPv4)
+	testResolveAddresses(t, resolver, []net.IP{ip4Address1, ip4Address2})
+	resolver = NewDNSResolver(ip4DNSResolver, "ip", 1, PreferIPv6)
+	testResolveAddresses(t, resolver, []net.IP{ip4Address1, ip4Address2})
+
+	// AAAA records only
+	ip6DNSResolver := newFakeDNSResolver(t, []dnsmessage.Resource{
+		ip6Address1Resource,
+		ip6Address2Resource,
+	})
+	resolver = NewDNSResolver(ip6DNSResolver, "ip", 1, AllFamilies)
+	testResolveAddresses(t, resolver, []net.IP{ip6Address1, ip6Address2})
+	resolver = NewDNSResolver(ip6DNSResolver, "ip", 1, PreferIPv4)
+	testResolveAddresses(t, resolver, []net.IP{ip6Address1, ip6Address2})
+	resolver = NewDNSResolver(ip6DNSResolver, "ip", 1, PreferIPv6)
+	testResolveAddresses(t, resolver, []net.IP{ip6Address1, ip6Address2})
+}
+
+func testResolveAddresses(
+	t *testing.T,
+	resolver Resolver,
+	expectedAddresses []net.IP,
+) {
+	t.Helper()
+
+	refreshCh := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+
+	testClock := clocktest.NewFakeClock()
+	resolver.(*pollingResolver).clock = testClock
+
+	resolved := make(chan []Address)
+	task := resolver.New(ctx, "http", "example.com", testReceiver{
+		onResolve: func(resolvedAddresses []Address) {
+			resolved <- resolvedAddresses
+		},
+		onResolveError: func(err error) {
+			t.Errorf("unexpected resolution error: %v", err)
+		},
+	}, refreshCh)
+
+	t.Cleanup(func() {
+		close(resolved)
+		err := task.Close()
+		close(refreshCh)
+		require.NoError(t, err)
+	})
+
+	select {
+	case resolvedAddresses := <-resolved:
+		actualAddresses := make([]net.IP, len(resolvedAddresses))
+		for i, address := range resolvedAddresses {
+			actualHost, _, err := net.SplitHostPort(address.HostPort)
+			require.NoError(t, err)
+			actualAddresses[i] = net.ParseIP(actualHost)
+		}
+		assert.ElementsMatch(t, expectedAddresses, actualAddresses)
+	case <-ctx.Done():
+		t.Fatal("expected call to resolver")
+	}
+}
+
 type testReceiver struct {
 	onResolve      func([]Address)
 	onResolveError func(error)
@@ -96,4 +217,78 @@ func (r testReceiver) OnResolve(addresses []Address) {
 
 func (r testReceiver) OnResolveError(err error) {
 	r.onResolveError(err)
+}
+
+type fakeDNSResolver struct {
+	t       *testing.T
+	answers []dnsmessage.Resource
+}
+
+func (r *fakeDNSResolver) Dial(context.Context, string, string) (net.Conn, error) {
+	clientConn, serverConn := net.Pipe()
+	go func() {
+		var requestLength uint16
+		if err := binary.Read(serverConn, binary.BigEndian, &requestLength); err != nil {
+			r.t.Errorf("error reading dns request length: %v", err)
+			return
+		}
+		requestData := make([]byte, requestLength)
+		if _, err := io.ReadFull(serverConn, requestData); err != nil {
+			r.t.Errorf("error reading dns request: %v", err)
+			return
+		}
+		request := &dnsmessage.Message{}
+		if err := request.Unpack(requestData); err != nil {
+			r.t.Errorf("error unpacking dns request: %v", err)
+			return
+		}
+		answers := []dnsmessage.Resource{}
+		for _, answer := range r.answers {
+			if answer.Header.Type == request.Questions[0].Type {
+				answers = append(answers, answer)
+			}
+		}
+		response := &dnsmessage.Message{
+			Header: dnsmessage.Header{
+				ID:            request.ID,
+				Response:      true,
+				RCode:         dnsmessage.RCodeSuccess,
+				Authoritative: true,
+			},
+			Questions: request.Questions,
+			Answers:   answers,
+		}
+		responseData, err := response.Pack()
+		if err != nil {
+			r.t.Errorf("error packing dns response: %v", err)
+			return
+		}
+		responseLength := uint16(len(responseData))
+		if err := binary.Write(serverConn, binary.BigEndian, &responseLength); err != nil {
+			r.t.Errorf("error writing dns response length: %v", err)
+			return
+		}
+		if _, err := serverConn.Write(responseData); err != nil {
+			r.t.Errorf("error writing dns response: %v", err)
+			return
+		}
+		if err := serverConn.Close(); err != nil {
+			r.t.Errorf("error closing dns server connection: %v", err)
+			return
+		}
+	}()
+	return clientConn, nil
+}
+
+func newFakeDNSResolver(t *testing.T, answers []dnsmessage.Resource) *net.Resolver {
+	t.Helper()
+
+	dialer := fakeDNSResolver{
+		t:       t,
+		answers: answers,
+	}
+	return &net.Resolver{
+		PreferGo: true,
+		Dial:     dialer.Dial,
+	}
 }


### PR DESCRIPTION
Implements address family policy. When the policy is set to `PreferIPv4` or `PreferIPv6`, any DNS result that has both IPv4 and IPv6 records will be filtered to only the preferred records; in cases where only IPv4 or IPv6 addresses are present, this has no impact. The default is set to `PreferIPv4` to help lower the likelihood of problems due to the fact that `httplb` lacks some kind of implementation of a "happy eyeballs" algorithm to perform IPv6 fallback.

It winds up being a little tricky to test this, but it's probably worthwhile; right now we can only test the DNS resolver in a fairly limited way (by relying on the fact that resolving an IP address is a no-op.) With this approach, we can test the DNS resolver more-or-less end-to-end.