### PR TITLE
Actualize timers usage for go 1.23

### DIFF
--- a/internal/clocktest/clocktest.go
+++ b/internal/clocktest/clocktest.go
@@ -80,7 +80,13 @@ func (f fakeClock) NewTicker(d time.Duration) internal.Ticker {
 // clockwork.Clock.NewTimer as a clock.Timer. See package comment for more
 // information on why this is necessary.
 func (f fakeClock) NewTimer(d time.Duration) internal.Timer {
-	return f.clockworkFakeClock.NewTimer(d)
+	t := f.clockworkFakeClock.NewTimer(d)
+	if d == 0 {
+		if !t.Stop() {
+			<-t.Chan()
+		}
+	}
+	return t
 }
 
 // AfterFunc implements clock.Clock by re-boxing the clockwork.Timer returned by

--- a/internal/clocktest/clocktest.go
+++ b/internal/clocktest/clocktest.go
@@ -82,6 +82,8 @@ func (f fakeClock) NewTicker(d time.Duration) internal.Ticker {
 func (f fakeClock) NewTimer(d time.Duration) internal.Timer {
 	t := f.clockworkFakeClock.NewTimer(d)
 	if d == 0 {
+		// Here we reproduce the pre-1.23 timers behavior since jonboulle/clockwork still have not fixed this yet,
+		// see the issue: https://github.com/jonboulle/clockwork/issues/98
 		if !t.Stop() {
 			<-t.Chan()
 		}

--- a/internal/clocktest/clocktest.go
+++ b/internal/clocktest/clocktest.go
@@ -80,15 +80,15 @@ func (f fakeClock) NewTicker(d time.Duration) internal.Ticker {
 // clockwork.Clock.NewTimer as a clock.Timer. See package comment for more
 // information on why this is necessary.
 func (f fakeClock) NewTimer(d time.Duration) internal.Timer {
-	t := f.clockworkFakeClock.NewTimer(d)
+	timer := f.clockworkFakeClock.NewTimer(d)
 	if d == 0 {
 		// Here we reproduce the pre-1.23 timers behavior since jonboulle/clockwork still have not fixed this yet,
 		// see the issue: https://github.com/jonboulle/clockwork/issues/98
-		if !t.Stop() {
-			<-t.Chan()
+		if !timer.Stop() {
+			<-timer.Chan()
 		}
 	}
-	return t
+	return timer
 }
 
 // AfterFunc implements clock.Clock by re-boxing the clockwork.Timer returned by

--- a/transport.go
+++ b/transport.go
@@ -382,7 +382,6 @@ func (m *mainTransport) getPoolLocked(dest target) *transportPool {
 
 func (m *mainTransport) closeWhenIdle(ctx context.Context, dest target, pool *transportPool, activity <-chan struct{}) {
 	timer := m.clock.NewTimer(m.idleTransportTimeout)
-	defer timer.Stop()
 	for {
 		select {
 		case <-timer.Chan():


### PR DESCRIPTION
Go 1.23 comes with behavior changes in timers, check out the full article: https://go.dev/wiki/Go123Timer

In short, three important changes:
- timers do not need to be closed if not used anymore
- you shouldn't bother about the state of timer before calling to `Reset` anymore
- channels **must not** be emptied after the `Stop()` returned `false`

The last part is very important, since existing calls to `<-timer.Chan()` now could lead to deadlocks, see godoc:

```
// For a chan-based timer created with NewTimer(d), as of Go 1.23,
// any receive from t.C after Stop has returned is guaranteed to block
// rather than receive a stale time value from before the Stop;
```
https://github.com/golang/go/blob/065c1359e1bc3d6744a925339484592b13d713dd/src/time/sleep.go#L105C1-L109C47