### PR TITLE
Add go1.24-specific implementation of "h2c" scheme

### DIFF
--- a/h2c_go123.go
+++ b/h2c_go123.go
@@ -1,0 +1,46 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.24
+
+package httplb
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"golang.org/x/net/http2"
+)
+
+// h2cTransport provides support for the "h2c" scheme, which is used to force
+// HTTP/2 over clear-text (no TLS), aka H2C. Prior to Go 1.24, we must use
+// features of the golang.org/x/net/http2 client implementation to make this
+// work.
+type h2cTransport struct{}
+
+func (s h2cTransport) NewRoundTripper(_, _ string, opts TransportConfig) RoundTripperResult {
+	// We can't support all round tripper options with H2C.
+	transport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return defaultDialer.DialContext(ctx, network, addr)
+		},
+		// We don't bother setting the TLS config, because h2c is plain-text only
+		//TLSClientConfig:   opts.TLSClientConfig,
+		MaxHeaderListSize:  uint32(opts.MaxResponseHeaderBytes),
+		DisableCompression: opts.DisableCompression,
+	}
+	return RoundTripperResult{RoundTripper: transport, Scheme: "http", Close: transport.CloseIdleConnections}
+}

--- a/h2c_go124.go
+++ b/h2c_go124.go
@@ -1,0 +1,56 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.24
+
+package httplb
+
+import (
+	"net/http"
+	"time"
+)
+
+// h2cTransport provides support for the "h2c" scheme, which is used to force
+// HTTP/2 over clear-text (no TLS), aka H2C. As of Go 1.24, this basically
+// looks just like simpleTransport (used for "http" and "https" schemes),
+// except that it must adjust the transport's supported protocols (as well as
+// transform the "h2c" scheme to "http").
+//
+// As of Go 1,24, many more transport config options can be supported with
+// H2C.
+type h2cTransport struct{}
+
+func (s h2cTransport) NewRoundTripper(_, _ string, opts TransportConfig) RoundTripperResult {
+	var protocols http.Protocols
+	protocols.SetUnencryptedHTTP2(true)
+
+	transport := &http.Transport{
+		Proxy:                  opts.ProxyFunc,
+		GetProxyConnectHeader:  opts.ProxyConnectHeadersFunc,
+		DialContext:            opts.DialFunc,
+		ForceAttemptHTTP2:      true,
+		MaxIdleConns:           1,
+		MaxIdleConnsPerHost:    1,
+		IdleConnTimeout:        opts.IdleConnTimeout,
+		TLSHandshakeTimeout:    opts.TLSHandshakeTimeout,
+		TLSClientConfig:        opts.TLSClientConfig,
+		MaxResponseHeaderBytes: opts.MaxResponseHeaderBytes,
+		ExpectContinueTimeout:  1 * time.Second,
+		DisableCompression:     opts.DisableCompression,
+		Protocols:              &protocols,
+	}
+	// no way to populate pre-warm function since http.Transport doesn't provide
+	// any way to do that :(
+	return RoundTripperResult{RoundTripper: transport, Scheme: "http", Close: transport.CloseIdleConnections}
+}

--- a/transport.go
+++ b/transport.go
@@ -34,7 +34,6 @@ import (
 	"github.com/bufbuild/httplb/internal"
 	"github.com/bufbuild/httplb/picker"
 	"github.com/bufbuild/httplb/resolver"
-	"golang.org/x/net/http2"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -143,23 +142,6 @@ func (s simpleTransport) NewRoundTripper(_, _ string, opts TransportConfig) Roun
 	// no way to populate pre-warm function since http.Transport doesn't provide
 	// any way to do that :(
 	return RoundTripperResult{RoundTripper: transport, Close: transport.CloseIdleConnections}
-}
-
-type h2cTransport struct{}
-
-func (s h2cTransport) NewRoundTripper(_, _ string, opts TransportConfig) RoundTripperResult {
-	// We can't support all round tripper options with H2C.
-	transport := &http2.Transport{
-		AllowHTTP: true,
-		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			return defaultDialer.DialContext(ctx, network, addr)
-		},
-		// We don't bother setting the TLS config, because h2c is plain-text only
-		//TLSClientConfig:   opts.TLSClientConfig,
-		MaxHeaderListSize:  uint32(opts.MaxResponseHeaderBytes),
-		DisableCompression: opts.DisableCompression,
-	}
-	return RoundTripperResult{RoundTripper: transport, Scheme: "http", Close: transport.CloseIdleConnections}
 }
 
 // mainTransport is the root of the transport hierarchy. For each target


### PR DESCRIPTION
As of Go 1.24, we no longer need to import "golang.org/x/net/http2" in order to support the "h2c" scheme (to force HTTP/2 over plain-text).

This adds a Go-1.24-specific implementation that uses the latest H2C features in "net/http". Build tags are used so that we continue using the old implementation for projects still using Go 1.23.