### PR TITLE
Fix flaky TestPollingChecker in health package

### DIFF
--- a/health/polling_test.go
+++ b/health/polling_test.go
@@ -42,24 +42,24 @@ func TestPollingChecker(t *testing.T) {
 	// StateUnhealthy (HTTP error)
 	connection := make(fakeConnChan)
 	close(connection)
-	err := checker.New(ctx, connection, tracker).Close()
-	require.NoError(t, err)
+	prober := checker.New(ctx, connection, tracker)
 	assert.Equal(t, StateUnhealthy, <-tracker)
+	require.NoError(t, prober.Close())
 
 	// StateUnhealthy (HTTP 5xx)
 	connection = make(fakeConnChan, 1)
 	connection <- &http.Response{StatusCode: http.StatusBadGateway, Body: http.NoBody}
-	err = checker.New(ctx, connection, tracker).Close()
-	require.NoError(t, err)
+	prober = checker.New(ctx, connection, tracker)
 	assert.Equal(t, StateUnhealthy, <-tracker)
+	require.NoError(t, prober.Close())
 	close(connection)
 
 	// StateHealthy (HTTP 2xx)
 	connection = make(fakeConnChan, 1)
 	connection <- &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
-	err = checker.New(ctx, connection, tracker).Close()
-	require.NoError(t, err)
+	prober = checker.New(ctx, connection, tracker)
 	assert.Equal(t, StateHealthy, <-tracker)
+	require.NoError(t, prober.Close())
 	close(connection)
 }
 


### PR DESCRIPTION
The previous formulation had a race condition between the prober completing its first probe in one goroutine and it being cancelled by a concurrent goroutine calling the `Close()` function (which would cancel the prober's context).

You can see two failures in a row here:
https://github.com/bufbuild/httplb/actions/runs/14962744579/attempts/3
It would also happen pretty reliable if you did `go test ./health -count 10`. So I'm a little surprised we haven't seen this flake be more of an issue. It's possible that the context-related fix in the PR from that failed CI run (#80) actually tickled things just enough to make it happen more frequently.