### PR TITLE
Re-enable checklocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ generate: $(BIN)/license-header ## Regenerate code and licenses
 .PHONY: lint
 lint: $(BIN)/golangci-lint $(BIN)/checklocks ## Lint
 	go vet ./...
-	#go vet -vettool=$(BIN)/checklocks ./...
+	go vet -vettool=$(BIN)/checklocks ./...
 	golangci-lint run
 
 .PHONY: lintfix
@@ -75,4 +75,4 @@ $(BIN)/golangci-lint: Makefile
 
 $(BIN)/checklocks: Makefile
 	@mkdir -p $(@D)
-	go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@v0.0.0-20250313000854-906fb319cc3a
+	go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@v0.0.0-20260108080055-5aa19429c3bd

--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ $(BIN)/golangci-lint: Makefile
 
 $(BIN)/checklocks: Makefile
 	@mkdir -p $(@D)
-	go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@v0.0.0-20260108080055-5aa19429c3bd
+	go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@v0.0.0-20260108061738-2f5377660b6f


### PR DESCRIPTION
This was disabled back when we upgraded to Go v1.23, because checklocks at the time had not yet made changes/fixes so it was compatible with Go v1.23. We are now on Go v1.24 (and need to move to Go v1.25 soon since it has been out for months), and the latest checklocks works fine with the newer Go versions. So it is past time to re-enable these checks.