### PR TITLE
Respect request context when wating for picker to initialize

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -667,7 +667,16 @@ func (t *transportPool) getConnection(request *http.Request) (conn.Conn, func(),
 	pickerPtr := t.picker.Load()
 
 	if pickerPtr == nil {
-		<-t.pickerInitialized
+		if request == nil {
+			<-t.pickerInitialized
+		} else {
+			ctx := request.Context()
+			select {
+			case <-t.pickerInitialized:
+			case <-ctx.Done():
+				return nil, nil, fmt.Errorf("picker not initialized: %w", ctx.Err())
+			}
+		}
 		pickerPtr = t.picker.Load()
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -667,15 +667,14 @@ func (t *transportPool) getConnection(request *http.Request) (conn.Conn, func(),
 	pickerPtr := t.picker.Load()
 
 	if pickerPtr == nil {
-		if request == nil {
-			<-t.pickerInitialized
-		} else {
-			ctx := request.Context()
-			select {
-			case <-t.pickerInitialized:
-			case <-ctx.Done():
-				return nil, nil, fmt.Errorf("picker not initialized: %w", ctx.Err())
-			}
+		var doneCh <-chan struct{}
+		if request != nil {
+			doneCh = request.Context().Done()
+		}
+		select {
+		case <-t.pickerInitialized:
+		case <-doneCh:
+			return nil, nil, fmt.Errorf("picker not initialized: %w", ctx.Err())
 		}
 		pickerPtr = t.picker.Load()
 	}

--- a/transport.go
+++ b/transport.go
@@ -674,7 +674,7 @@ func (t *transportPool) getConnection(request *http.Request) (conn.Conn, func(),
 		select {
 		case <-t.pickerInitialized:
 		case <-doneCh:
-			return nil, nil, fmt.Errorf("picker not initialized: %w", ctx.Err())
+			return nil, nil, fmt.Errorf("picker not initialized: %w", request.Context().Err())
 		}
 		pickerPtr = t.picker.Load()
 	}


### PR DESCRIPTION
If the transport pool doesn't get properly initialized a http requests will hang forever. This prevents this by respecting the context. It will improve the failure mode so it doesn't accumulate goroutines and eventually prevents other parts from working.